### PR TITLE
Proper capitalization of PlistBuddy

### DIFF
--- a/bin/autoincrement-buildnumber.sh
+++ b/bin/autoincrement-buildnumber.sh
@@ -16,4 +16,4 @@ if [ -z "$buildnum" ]; then
     exit 1
 fi
 
-/usr/libexec/Plistbuddy -c "Set CFBundleVersion $buildnum" "$infoplist"
+/usr/libexec/PlistBuddy -c "Set CFBundleVersion $buildnum" "$infoplist"


### PR DESCRIPTION
Hello! I encountered following error while trying to build this framework.
`/Users/sust/dev/swift/macos/VolumeTest/VolumeTest/Carthage/Checkouts/AMCoreAudio/bin/autoincrement-buildnumber.sh: line 19: /usr/libexec/Plistbuddy: No such file or directory`

This happens because I’m using case-sensitive file system. 
Changing it to `PlistBuddy` resolved this error.