### PR TITLE
Concurrency issues fix

### DIFF
--- a/AMCoreAudio.podspec
+++ b/AMCoreAudio.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AMCoreAudio'
-  s.version      = '3.4'
+  s.version      = '3.4-develop'
   s.summary      = 'A Swift framework that aims to make Core Audio use less tedious in macOS'
 
   s.description  = <<-DESC
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   s.platform     = :osx, '10.10'
   s.osx.deployment_target = '10.10'
 
-  s.source       = { :git => 'https://github.com/rnine/AMCoreAudio.git', :tag => s.version }
-  s.source_files = 'AMCoreAudio/*.{swift,h,m}'
+  s.source       = { :git => 'https://github.com/fbarbat/AMCoreAudio.git', :branch => 'develop' }
+  s.source_files = 'Source/**/*.{swift,h,m}'
 
   s.requires_arc = true
 

--- a/Source/Public/AudioDevice.swift
+++ b/Source/Public/AudioDevice.swift
@@ -24,8 +24,6 @@ public final class AudioDevice: AudioObject {
 
     private var isRegisteredForNotifications = false
 
-    private let notificationsQueue = DispatchQueue.global(qos: .userInitiated)
-
     private lazy var propertyListenerBlock: AudioObjectPropertyListenerBlock = { [weak self] (_, inAddresses) -> Void in
         let address = inAddresses.pointee
         let notificationCenter = NotificationCenter.defaultCenter
@@ -1362,7 +1360,7 @@ public final class AudioDevice: AudioObject {
             mElement: kAudioObjectPropertyElementWildcard
         )
 
-        let err = AudioObjectAddPropertyListenerBlock(id, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectAddPropertyListenerBlock(id, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectAddPropertyListenerBlock: \(err)")
@@ -1380,7 +1378,7 @@ public final class AudioDevice: AudioObject {
             mElement: kAudioObjectPropertyElementWildcard
         )
 
-        let err = AudioObjectRemovePropertyListenerBlock(id, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectRemovePropertyListenerBlock(id, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectRemovePropertyListenerBlock: \(err)")

--- a/Source/Public/AudioHardware.swift
+++ b/Source/Public/AudioHardware.swift
@@ -19,7 +19,6 @@ public final class AudioHardware {
     private var allKnownDevices = [AudioDevice]()
     private var isRegisteredForNotifications = false
 
-    private let notificationsQueue = DispatchQueue.global(qos: .userInitiated)
 
     private lazy var propertyListenerBlock: AudioObjectPropertyListenerBlock = { [weak self] (_, inAddresses) -> Void in
         let address = inAddresses.pointee
@@ -128,7 +127,7 @@ public final class AudioHardware {
         )
 
         let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
-        let err = AudioObjectAddPropertyListenerBlock(systemObjectID, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectAddPropertyListenerBlock(systemObjectID, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectAddPropertyListenerBlock: \(err)")
@@ -147,7 +146,7 @@ public final class AudioHardware {
         )
 
         let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
-        let err = AudioObjectRemovePropertyListenerBlock(systemObjectID, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectRemovePropertyListenerBlock(systemObjectID, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectRemovePropertyListenerBlock: \(err)")

--- a/Source/Public/AudioStream.swift
+++ b/Source/Public/AudioStream.swift
@@ -245,8 +245,6 @@ public final class AudioStream: AudioObject {
 
     private var isRegisteredForNotifications = false
 
-    private let notificationsQueue = DispatchQueue.global(qos: .userInitiated)
-
     private lazy var propertyListenerBlock: AudioObjectPropertyListenerBlock = { (_, inAddresses) -> Void in
         let address = inAddresses.pointee
         let direction = AMCoreAudio.direction(to: address.mScope)
@@ -405,7 +403,7 @@ public final class AudioStream: AudioObject {
             mElement: kAudioObjectPropertyElementWildcard
         )
 
-        let err = AudioObjectAddPropertyListenerBlock(id, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectAddPropertyListenerBlock(id, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectAddPropertyListenerBlock: \(err)")
@@ -423,7 +421,7 @@ public final class AudioStream: AudioObject {
             mElement: kAudioObjectPropertyElementWildcard
         )
 
-        let err = AudioObjectRemovePropertyListenerBlock(id, &address, notificationsQueue, propertyListenerBlock)
+        let err = AudioObjectRemovePropertyListenerBlock(id, &address, NotificationCenter.notificationsQueue, propertyListenerBlock)
 
         if noErr != err {
             log("Error on AudioObjectRemovePropertyListenerBlock: \(err)")

--- a/Source/Public/NotificationCenter.swift
+++ b/Source/Public/NotificationCenter.swift
@@ -20,7 +20,9 @@ public final class NotificationCenter {
     private var subscriberDescriptorsByEvent = [String: [EventSubscriberDescriptor]]()
 
     private init() {}
-
+    
+    static let notificationsQueue = DispatchQueue(label: "AMCoreAudioNotificationsQueue", target: DispatchQueue.global(qos: .userInitiated))
+    
     /// Returns a singleton `NotificationCenter` instance.
     public static let defaultCenter = NotificationCenter()
 


### PR DESCRIPTION
Hello,

We have been using AMCoreAudio for our app because it really simplifies device access. Thanks for the project!

However, we saw several crashes on our users. All of them start by AudioHardware.propertyListenerBlock.getter and end up in crash in a non thread safe class such as NSConcreteMapTable or Array. 

Reviewing the code we found that AMCoreAudio was using a concurrent global queue for delivering notifications and that is probably what is causing the issue.

In this pull request we just created a serial queue and used that same queue in all the places AMCoreAudio needed a notification queue for CoreAudio callbacks.

Do you think this is a good solution for this issue in AMCoreAudio?

Please note that I did some changes in the podspec in order to test it. That should be changed before merging this fork.

Thanks!
