### PR TITLE
Added support for identifying, creating and destroying Aggregate Devices

### DIFF
--- a/Source/Public/AudioDevice+Aggregate.swift
+++ b/Source/Public/AudioDevice+Aggregate.swift
@@ -1,0 +1,95 @@
+//  AudioDevice+Aggregate.swift
+//  Created by Ryan Francesconi on 2/24/21.
+//  Copyright © 2021 9Labs. All rights reserved.
+
+import AudioToolbox.AudioServices
+
+extension AudioDevice {
+    /// - Returns: `true` if this device is an aggregate one, `false` otherwise.
+    public func isAggregateDevice() -> Bool {
+        guard let aggregateDevices = ownedAggregateDevices() else { return false }
+        return aggregateDevices.count > 0
+    }
+
+    /// All the subdevices of this aggregate device
+    ///
+    /// - Returns: An array of `AudioDevice` objects.
+    public func ownedAggregateDevices() -> [AudioDevice]? {
+        guard let ownedObjectIDs = ownedObjectIDs() else { return nil }
+
+        let ownedDevices = ownedObjectIDs.compactMap { (id) -> AudioDevice? in
+            AudioDevice.lookup(by: id)
+        }
+        // only aggregates have non nil owned UIDs. I think?
+        return ownedDevices.filter { $0.uid != nil }
+    }
+
+    /// All the subdevices of this aggregate device that support input
+    ///
+    /// - Returns: An array of `AudioDevice` objects.
+    public func ownedAggregateInputDevices() -> [AudioDevice]? {
+        ownedAggregateDevices()?.filter {
+            guard let channels = $0.layoutChannels(direction: .recording) else { return false }
+            return channels > 0
+        }
+    }
+
+    /// All the subdevices of this aggregate device that support output
+    ///
+    /// - Returns: An array of `AudioDevice` objects.
+    public func ownedAggregateOutputDevices() -> [AudioDevice]? {
+        ownedAggregateDevices()?.filter {
+            guard let channels = $0.layoutChannels(direction: .playback) else { return false }
+            return channels > 0
+        }
+    }
+
+    // MARK: - Create and Destroy Aggregate Devices
+
+    /// This routine creates a new Aggregate AudioDevice
+    ///
+    /// - Parameter masterDeviceUID: An audio device unique identifier. This will also be the clock source.
+    /// - Parameter secondDeviceUID: An audio device unique identifier
+    ///
+    /// - Returns *(optional)* An aggregate `AudioDevice` if one can be created.
+    public static func createAggregateDevice(masterDeviceUID: String,
+                                             secondDeviceUID: String?,
+                                             named name: String,
+                                             uid: String) -> AudioDevice? {
+        var deviceList: [[String: Any]] = [
+            [kAudioSubDeviceUIDKey: masterDeviceUID],
+        ]
+
+        // make sure same device isn't added twice
+        if let secondDeviceUID = secondDeviceUID,
+           secondDeviceUID != masterDeviceUID {
+            deviceList.append([kAudioSubDeviceUIDKey: secondDeviceUID])
+        }
+
+        let desc: [String: Any] = [
+            kAudioAggregateDeviceNameKey: name,
+            kAudioAggregateDeviceUIDKey: uid,
+            kAudioAggregateDeviceSubDeviceListKey: deviceList,
+            kAudioAggregateDeviceMasterSubDeviceKey: masterDeviceUID,
+        ]
+
+        var deviceID: AudioDeviceID = 0
+        let error = AudioHardwareCreateAggregateDevice(desc as CFDictionary, &deviceID)
+
+        guard error == noErr else {
+            log("Failed creating aggregate device with error: \(error)")
+            return nil
+        }
+        return AudioDevice.lookup(by: deviceID)
+    }
+
+    /// Destroy the given AudioAggregateDevice.
+    ///
+    /// The actual destruction of the device is asynchronous and may take place after
+    /// the call to this routine has returned.
+    /// - Parameter id: The AudioObjectID of the AudioAggregateDevice to destroy.
+    /// - Returns An OSStatus indicating success or failure.
+    public static func removeAggregateDevice(id deviceID: AudioObjectID) -> OSStatus {
+        AudioHardwareDestroyAggregateDevice(deviceID)
+    }
+}

--- a/Tests/AMCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/AMCoreAudioTests/AudioDeviceTests.swift
@@ -484,6 +484,6 @@ final class AudioDeviceTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
             delayExpectation.fulfill()
         }
-        wait(for: [delayExpectation], timeout: interval)
+        wait(for: [delayExpectation], timeout: interval + 1)
     }
 }

--- a/Tests/AMCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/AMCoreAudioTests/AudioDeviceTests.swift
@@ -439,12 +439,15 @@ final class AudioDeviceTests: XCTestCase {
             XCTFail("Failed creating device")
             return
         }
-        
+
+        XCTAssertTrue(device.isAggregateDevice())
+        XCTAssertTrue(device.ownedAggregateDevices()?.count == 2)
+
         wait(for: 2)
 
         let error = AudioDevice.removeAggregateDevice(id: device.id)
         XCTAssertTrue(error == noErr, "Failed removing device")
-        
+
         wait(for: 2)
     }
 


### PR DESCRIPTION
Feel free to reject, but noticed aggregate support was missing so I looked into it as I was messing with them. Seems like it should be in here.

Thanks for the nice work!

Ryan