### PR TITLE
Fix typo in AudioHardware.allOutputDevices

### DIFF
--- a/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
+++ b/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
@@ -55,7 +55,7 @@ final class AudioHardware {
     }
 
     var allOutputDevices: [AudioDevice] {
-        allDevices.filter { $0.channels(scope: .input) > 0 }
+        allDevices.filter { $0.channels(scope: .output) > 0 }
     }
 
     var allIODevices: [AudioDevice] {


### PR DESCRIPTION
It appears there was a typo in allOutputDevices that prevented it from returning output devices. This PR fixes that.

Thank you for a great package!