### PR TITLE
two more property listeners added, changes to Scope enum

### DIFF
--- a/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
+++ b/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
@@ -152,7 +152,7 @@ fileprivate extension AudioHardware {
 
 private func propertyListener(objectID: UInt32,
                               numInAddresses: UInt32,
-                              inAddresses : UnsafePointer<AudioObjectPropertyAddress>,
+                              inAddresses: UnsafePointer<AudioObjectPropertyAddress>,
                               clientData: Optional<UnsafeMutableRawPointer>) -> Int32 {
     let _self = Unmanaged<AudioHardware>.fromOpaque(clientData!).takeUnretainedValue()
     let address = inAddresses.pointee
@@ -183,7 +183,7 @@ private func propertyListener(objectID: UInt32,
 
         let userInfo: [AnyHashable: Any] = [
             "addedDevices": addedDevices,
-            "removedDevices": removedDevices
+            "removedDevices": removedDevices,
         ]
 
         notificationCenter.post(name: .deviceListChanged, object: _self, userInfo: userInfo)
@@ -194,7 +194,6 @@ private func propertyListener(objectID: UInt32,
     case kAudioHardwarePropertyDefaultSystemOutputDevice:
         notificationCenter.post(name: .defaultSystemOutputDeviceChanged, object: _self)
     default:
-        os_log("Unhandled mSelector %@.", address.mSelector)
         break
     }
 

--- a/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
+++ b/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
@@ -194,6 +194,7 @@ private func propertyListener(objectID: UInt32,
     case kAudioHardwarePropertyDefaultSystemOutputDevice:
         notificationCenter.post(name: .defaultSystemOutputDeviceChanged, object: _self)
     default:
+        os_log("Unhandled mSelector %@.", address.mSelector)
         break
     }
 

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -33,4 +33,11 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
+    
+    func bufferFrameSize(scope: Scope) -> UInt32? {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
+                                         scope: scope.asPropertyScope) else { return nil }
+
+        return getProperty(address: address)
+    }
 }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -33,7 +33,12 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
-    
+   
+    /// The current size of the IO Buffer
+    ///
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: *(optional)* A `UInt32` value that indicates the number of frames in the IO buffers.
     func bufferFrameSize(scope: Scope) -> UInt32? {
         guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
                                          scope: scope.asPropertyScope) else { return nil }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -223,8 +223,6 @@ private func propertyListener(objectID: UInt32,
         notificationCenter.post(name: .devicePropertyIOStoppedAbnormally, object: obj)
 
     default:
-        os_log("Unhandled mSelector %@.", address.mSelector)
-
         break
     }
 

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -191,14 +191,14 @@ private func propertyListener(objectID: UInt32,
     case kAudioDevicePropertyVolumeScalar:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope)!,
+            "scope": Scope.from(address.mScope) ?? .global,
         ]
 
         notificationCenter.post(name: .deviceVolumeDidChange, object: obj, userInfo: userInfo)
     case kAudioDevicePropertyMute:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope)!,
+            "scope": Scope.from(address.mScope) ?? .global,
         ]
 
         notificationCenter.post(name: .deviceMuteDidChange, object: obj, userInfo: userInfo)
@@ -214,13 +214,12 @@ private func propertyListener(objectID: UInt32,
         notificationCenter.post(name: .devicePreferredChannelsForStereoDidChange, object: obj)
     case kAudioDevicePropertyHogMode:
         notificationCenter.post(name: .deviceHogModeDidChange, object: obj)
-
     case kAudioDeviceProcessorOverload:
         notificationCenter.post(name: .deviceProcessorOverload, object: obj)
     case kAudioDevicePropertyIOCycleUsage:
-        notificationCenter.post(name: .devicePropertyIOCycleUsage, object: obj)
+        notificationCenter.post(name: .deviceIOCycleUsage, object: obj)
     case kAudioDevicePropertyIOStoppedAbnormally:
-        notificationCenter.post(name: .devicePropertyIOStoppedAbnormally, object: obj)
+        notificationCenter.post(name: .deviceIOStoppedAbnormally, object: obj)
 
     default:
         break

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -19,7 +19,7 @@ public final class AudioDevice: AudioObject {
         kAudioSubDeviceClassID,
         kAudioAggregateDeviceClassID,
         kAudioEndPointClassID,
-        kAudioEndPointDeviceClassID
+        kAudioEndPointDeviceClassID,
     ]
 
     // MARK: - Internal Properties
@@ -57,7 +57,7 @@ public final class AudioDevice: AudioObject {
     /// The audio device's name as reported by Core Audio.
     ///
     /// - Returns: An audio device's name.
-    public override var name: String { super.name ?? cachedDeviceName ?? "<Unknown Device Name>" }
+    override public var name: String { super.name ?? cachedDeviceName ?? "<Unknown Device Name>" }
 }
 
 // MARK: - Class Functions
@@ -169,7 +169,7 @@ extension AudioDevice: CustomStringConvertible {
 
 private func propertyListener(objectID: UInt32,
                               numInAddresses: UInt32,
-                              inAddresses : UnsafePointer<AudioObjectPropertyAddress>,
+                              inAddresses: UnsafePointer<AudioObjectPropertyAddress>,
                               clientData: Optional<UnsafeMutableRawPointer>) -> Int32 {
     // Try to get audio object from the pool.
     guard let obj: AudioDevice = AudioObjectPool.shared.get(objectID) else { return kAudioHardwareBadObjectError }
@@ -191,14 +191,14 @@ private func propertyListener(objectID: UInt32,
     case kAudioDevicePropertyVolumeScalar:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope)!
+            "scope": Scope.from(address.mScope)!,
         ]
 
         notificationCenter.post(name: .deviceVolumeDidChange, object: obj, userInfo: userInfo)
     case kAudioDevicePropertyMute:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope)!
+            "scope": Scope.from(address.mScope)!,
         ]
 
         notificationCenter.post(name: .deviceMuteDidChange, object: obj, userInfo: userInfo)
@@ -214,7 +214,17 @@ private func propertyListener(objectID: UInt32,
         notificationCenter.post(name: .devicePreferredChannelsForStereoDidChange, object: obj)
     case kAudioDevicePropertyHogMode:
         notificationCenter.post(name: .deviceHogModeDidChange, object: obj)
+
+    case kAudioDeviceProcessorOverload:
+        notificationCenter.post(name: .deviceProcessorOverload, object: obj)
+    case kAudioDevicePropertyIOCycleUsage:
+        notificationCenter.post(name: .devicePropertyIOCycleUsage, object: obj)
+    case kAudioDevicePropertyIOStoppedAbnormally:
+        notificationCenter.post(name: .devicePropertyIOStoppedAbnormally, object: obj)
+
     default:
+        os_log("Unhandled mSelector %@.", address.mSelector)
+
         break
     }
 

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -216,8 +216,6 @@ private func propertyListener(objectID: UInt32,
         notificationCenter.post(name: .deviceHogModeDidChange, object: obj)
     case kAudioDeviceProcessorOverload:
         notificationCenter.post(name: .deviceProcessorOverload, object: obj)
-    case kAudioDevicePropertyIOCycleUsage:
-        notificationCenter.post(name: .deviceIOCycleUsage, object: obj)
     case kAudioDevicePropertyIOStoppedAbnormally:
         notificationCenter.post(name: .deviceIOStoppedAbnormally, object: obj)
 

--- a/Sources/SimplyCoreAudio/Public/Enums/Scope.swift
+++ b/Sources/SimplyCoreAudio/Public/Enums/Scope.swift
@@ -12,14 +12,28 @@ import Foundation
 /// Please notice that `AudioStream` only supports `input` and `output` scopes,
 /// whether as `AudioDevice` may, additionally, support `global` and `playthrough`.
 public enum Scope {
-    /// Global scope
+    /// The AudioObjectPropertyScope for properties that apply to the object as a
+    /// whole. All objects have a global scope and for most it is their only scope.
     case global
-    /// Input scope
+
+    /// The AudioObjectPropertyScope for properties that apply to the input side of
+    /// an object
     case input
-    /// Output scope
+
+    /// The AudioObjectPropertyScope for properties that apply to the output side of
+    /// an object.
     case output
-    /// Playthrough scope
+
+    /// The AudioObjectPropertyScope for properties that apply to the play through
+    /// side of an object.
     case playthrough
+
+    /// The AudioObjectPropertyElement value for properties that apply to the master
+    /// element or to the entire scope.
+    case master
+
+    /// The wildcard value for AudioObjectPropertySelectors
+    case wildcard
 }
 
 // MARK: - Internal Functions
@@ -31,16 +45,26 @@ extension Scope {
         case .input: return kAudioObjectPropertyScopeInput
         case .output: return kAudioObjectPropertyScopeOutput
         case .playthrough: return kAudioObjectPropertyScopePlayThrough
+        case .master: return kAudioObjectPropertyElementMaster
+        case .wildcard: return kAudioObjectPropertyScopeWildcard
         }
     }
 
-    static func from(_ scope: AudioObjectPropertyScope) -> Scope? {
+    static func from(_ scope: AudioObjectPropertyScope) -> Scope {
         switch scope {
         case kAudioObjectPropertyScopeGlobal: return .global
         case kAudioObjectPropertyScopeInput: return .input
         case kAudioObjectPropertyScopeOutput: return .output
         case kAudioObjectPropertyScopePlayThrough: return .playthrough
-        default: return nil
+        case kAudioObjectPropertyElementMaster: return .master
+        case kAudioObjectPropertyScopeWildcard: return .wildcard
+        default:
+            // Note, the default is only here to satisfy the switch to be exhaustive.
+            // It already defines the complete set of AudioObjectPropertyScope from
+            // AudioHardware.h, so it's pretty unlikely this would be returned. The
+            // only case should be if Apple adds a new scope type - which seems fairly
+            // unlikely
+            return .wildcard
         }
     }
 }

--- a/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
+++ b/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
@@ -81,12 +81,6 @@ public extension Notification.Name {
     /// usually sent from the AudioDevice's IO thread.
     static let deviceProcessorOverload = Self("deviceProcessorOverload")
 
-    /// A Float32 whose range is from 0 to 1. This value indicates how much of the
-    /// client portion of the IO cycle the process will use. The client portion of
-    /// the IO cycle is the portion of the cycle in which the device calls the
-    /// IOProcs so this property does not the apply to the duration of the entire cycle.
-    static let deviceIOCycleUsage = Self("deviceIOCycleUsage")
-
     /// Called when IO on the device has stopped outside of the
     /// normal mechanisms. This typically comes up when IO is stopped after
     /// AudioDeviceStart has returned successfully but prior to the notification for

--- a/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
+++ b/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
@@ -76,6 +76,23 @@ public extension Notification.Name {
     /// Called whenever the audio device's *hog mode* property changes.
     static let deviceHogModeDidChange = Self("deviceHogModeDidChange")
 
+    /// Called when the AudioDevice detects that an IO cycle has
+    /// run past its deadline. Note that the notification for this property is
+    /// usually sent from the AudioDevice's IO thread.
+    static let deviceProcessorOverload = Self("deviceProcessorOverload")
+
+    /// A Float32 whose range is from 0 to 1. This value indicates how much of the
+    /// client portion of the IO cycle the process will use. The client portion of
+    /// the IO cycle is the portion of the cycle in which the device calls the
+    /// IOProcs so this property does not the apply to the duration of the entire cycle.
+    static let deviceIOCycleUsage = Self("deviceIOCycleUsage")
+
+    /// Called when IO on the device has stopped outside of the
+    /// normal mechanisms. This typically comes up when IO is stopped after
+    /// AudioDeviceStart has returned successfully but prior to the notification for
+    /// kAudioDevicePropertyIsRunning being sent.
+    static let deviceIOStoppedAbnormally = Self("deviceIOStoppedAbnormally")
+
     // MARK: - Audio Stream Notifications
 
     /// Called whenever the audio stream `isActive` flag changes.
@@ -83,10 +100,6 @@ public extension Notification.Name {
 
     /// Called whenever the audio stream physical format changes.
     static let streamPhysicalFormatDidChange = Self("streamPhysicalFormatDidChange")
-
-    static let deviceProcessorOverload = Self("deviceProcessorOverload")
-    static let devicePropertyIOCycleUsage = Self("devicePropertyIOCycleUsage")
-    static let devicePropertyIOStoppedAbnormally = Self("devicePropertyIOStoppedAbnormally")
 }
 
 private extension Notification.Name {

--- a/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
+++ b/Sources/SimplyCoreAudio/Public/Extensions/Notification.Name+Extensions.swift
@@ -83,6 +83,10 @@ public extension Notification.Name {
 
     /// Called whenever the audio stream physical format changes.
     static let streamPhysicalFormatDidChange = Self("streamPhysicalFormatDidChange")
+
+    static let deviceProcessorOverload = Self("deviceProcessorOverload")
+    static let devicePropertyIOCycleUsage = Self("devicePropertyIOCycleUsage")
+    static let devicePropertyIOStoppedAbnormally = Self("devicePropertyIOStoppedAbnormally")
 }
 
 private extension Notification.Name {


### PR DESCRIPTION
I mostly needed this one: `kAudioDeviceProcessorOverload`, also added `kAudioDevicePropertyIOStoppedAbnormally` which i haven't yet seen but sounds fun.

the overload one is linked to this event that the HAL likes spits out:

`AudioHAL_Client	default	20:12:24.301357 -0700	ADD	HALC_ProxyIOContext.cpp:1068:IOWorkLoop:  HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload`

If you use AVAudioEngine at all and max it out, this is the event that happens.

Let me know if it looks ok!

