### PR TITLE
Added Buffer Frame Size functions and OSLog refinements

### DIFF
--- a/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
+++ b/Sources/SimplyCoreAudio/Internal/AudioHardware.swift
@@ -122,7 +122,8 @@ fileprivate extension AudioHardware {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
 
         if noErr != AudioObjectAddPropertyListener(systemObjectID, &address, propertyListener, selfPtr) {
-            os_log("Unable to add property listener for systemObjectID: %@.", systemObjectID)
+            OSLog.error("Unable to add property listener for systemObjectID:", systemObjectID)
+            
         } else {
             isRegisteredForNotifications = true
         }
@@ -141,7 +142,7 @@ fileprivate extension AudioHardware {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
 
         if noErr != AudioObjectRemovePropertyListener(systemObjectID, &address, propertyListener, selfPtr) {
-            os_log("Unable to remove property listener for systemObjectID: %@.", systemObjectID)
+            OSLog.error("Unable to remove property listener for systemObjectID:", systemObjectID)
         } else {
             isRegisteredForNotifications = false
         }

--- a/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
@@ -292,7 +292,7 @@ extension AudioObject {
 
     func validAddress(selector: AudioObjectPropertySelector,
                       scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
-                      element: AudioObjectPropertyElement = kAudioObjectPropertyElementMaster)-> AudioObjectPropertyAddress? {
+                      element: AudioObjectPropertyElement = kAudioObjectPropertyElementMaster) -> AudioObjectPropertyAddress? {
         var address = self.address(selector: selector, scope: scope, element: element)
 
         guard AudioObjectHasProperty(objectID, &address) else { return nil }
@@ -309,10 +309,7 @@ extension AudioObject {
         case noErr:
             return value
         default:
-            os_log("Unable to get property with address (%@). Status: %@",
-                   log: .default,
-                   type: .debug,
-                   String(describing: address), status)
+            OSLog.error("Unable to get property with address (\(address)).", "Status:", status)
             return nil
         }
     }
@@ -362,10 +359,7 @@ extension AudioObject {
         case noErr:
             return true
         default:
-            os_log("Unable to set property with address (%@). Status: %@",
-                   log: .default,
-                   type: .debug,
-                   String(describing: address), status)
+            OSLog.error("Unable to get property with address (\(address)).", "Status:", status)
             return false
         }
     }

--- a/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
@@ -8,8 +8,40 @@ import Foundation
 import os.log
 
 extension OSLog {
-    private static let subsystem = Bundle.main.bundleIdentifier!
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "io.9labs.SimplyCoreAudio"
 
     /// Default logger.
-    static let `default` = OSLog(subsystem: subsystem, category: "default")
+    static let `default` = OSLog(subsystem: subsystem, category: "Debug")
+
+    /// Error logger.
+    static let error = OSLog(subsystem: subsystem, category: "Errors")
+
+    /// Convenience for error messages with reference to what file the error came from
+    public static func error(fullname: String = #function,
+                             file: String = #file,
+                             line: Int = #line, _ items: Any?...) {
+        let fileName = (file as NSString).lastPathComponent
+
+        let content = (items.map {
+            String(describing: $0 ?? "nil")
+        }).joined(separator: " ")
+
+        let message = "🚩 \(fileName):\(fullname):\(line):\(content)"
+        os_log("%{public}@", log: .error, type: .error, message)
+    }
+
+    /// Convenience for debug messages with reference to what file the error came from
+    public static func debug(fullname: String = #function,
+                             file: String = #file,
+                             line: Int = #line,
+                             _ items: Any?...) {
+        let fileName = (file as NSString).lastPathComponent
+
+        let content = (items.map {
+            String(describing: $0 ?? "nil")
+        }).joined(separator: " ")
+
+        let message = "\(fileName):\(fullname):\(line):\(content)"
+        os_log("%{public}@", log: .default, type: .default, message)
+    }
 }

--- a/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
@@ -8,18 +8,20 @@ import Foundation
 import os.log
 
 extension OSLog {
-    private static let subsystem = Bundle.main.bundleIdentifier ?? "io.9labs.SimplyCoreAudio"
+    fileprivate static let subsystem = Bundle.main.bundleIdentifier ?? "io.9labs.SimplyCoreAudio"
 
     /// Default logger.
-    private static let `default` = OSLog(subsystem: subsystem, category: "Debug")
+    fileprivate static let `default` = OSLog(subsystem: subsystem, category: "Debug")
 
     /// Error logger.
-    private static let error = OSLog(subsystem: subsystem, category: "Errors")
+    fileprivate static let error = OSLog(subsystem: subsystem, category: "Errors")
+}
 
+extension OSLog {
     /// Convenience for error messages with reference to what file the error came from
-    public static func error(fullname: String = #function,
-                             file: String = #file,
-                             line: Int = #line, _ items: Any?...) {
+    static func error(fullname: String = #function,
+                      file: String = #file,
+                      line: Int = #line, _ items: Any?...) {
         let fileName = (file as NSString).lastPathComponent
 
         let content = (items.map {
@@ -31,10 +33,10 @@ extension OSLog {
     }
 
     /// Convenience for debug messages with reference to what file the error came from
-    public static func debug(fullname: String = #function,
-                             file: String = #file,
-                             line: Int = #line,
-                             _ items: Any?...) {
+    static func debug(fullname: String = #function,
+                      file: String = #file,
+                      line: Int = #line,
+                      _ items: Any?...) {
         let fileName = (file as NSString).lastPathComponent
 
         let content = (items.map {

--- a/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
@@ -11,10 +11,10 @@ extension OSLog {
     private static let subsystem = Bundle.main.bundleIdentifier ?? "io.9labs.SimplyCoreAudio"
 
     /// Default logger.
-    static let `default` = OSLog(subsystem: subsystem, category: "Debug")
+    private static let `default` = OSLog(subsystem: subsystem, category: "Debug")
 
     /// Error logger.
-    static let error = OSLog(subsystem: subsystem, category: "Errors")
+    private static let error = OSLog(subsystem: subsystem, category: "Errors")
 
     /// Convenience for error messages with reference to what file the error came from
     public static func error(fullname: String = #function,

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -45,4 +45,66 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
+
+    @discardableResult
+    func setBufferFrameSize(_ frameSize: UInt32, scope: Scope) -> Bool {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
+                                         scope: scope.asPropertyScope) else { return false }
+
+        return setProperty(address: address, value: frameSize)
+    }
+}
+
+public extension AudioDevice {
+    /// Calculate the fixed latency from the system and the device.
+    /// Sum of kAudioStreamPropertyLatency +
+    ///        kAudioDevicePropertySafetyOffset +
+    ///        kAudioDevicePropertyLatency
+
+    /**
+     Calculate the fixed latency from the system and the device.
+
+     In the general case the latency for a stream on a device is determined by the sum of the following properties:
+     kAudioDevicePropertySafetyOffset
+     kAudioStreamPropertyLatency
+     kAudioDevicePropertyLatency
+     kAudioDevicePropertyBufferFrameSize
+     */
+    struct FixedLatency {
+        var streamFrames: UInt32 = 0
+        var deviceFrames: UInt32 = 0
+        var safeteyOffsetFrames: UInt32 = 0
+        var bufferFrameSizeFrames: UInt32 = 0
+
+        var totalFrames: UInt32 {
+            streamFrames + deviceFrames + safeteyOffsetFrames + bufferFrameSizeFrames
+        }
+    }
+
+    func presentationLatency(scope: Scope) -> FixedLatency {
+        var object = FixedLatency()
+
+        if let allStreams = streams(scope: scope) {
+            // sum all of them or just take the first stream?
+            let frames = allStreams.compactMap { $0.latency }
+            object.streamFrames = frames.reduce(0, +)
+        }
+
+        if let frames = latency(scope: scope) {
+            object.deviceFrames = frames
+        }
+
+        if let frames = safetyOffset(scope: scope) {
+            object.safeteyOffsetFrames = frames
+        }
+
+        // kAudioDevicePropertyBufferFrameSize
+        // kAudioDevicePropertyBufferFrameSizeRange
+
+        if let frames = bufferFrameSize(scope: scope) {
+            object.bufferFrameSizeFrames = frames // * 2
+        }
+
+        return object
+    }
 }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -61,7 +61,7 @@ public extension AudioDevice {
         return setProperty(address: address, value: frameSize)
     }
 
-    /// A common array of UIInt32 values representing the available
+    /// A common array of UInt32 values representing the available
     /// IO buffer size options for the AudioStream containing the given element.
     ///
     /// - Parameter scope: A scope.

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -70,7 +70,7 @@ public extension AudioDevice {
      kAudioDevicePropertyLatency
      kAudioDevicePropertyBufferFrameSize
      */
-    struct FixedLatency {
+    public struct FixedLatency {
         var streamFrames: UInt32 = 0
         var deviceFrames: UInt32 = 0
         var safeteyOffsetFrames: UInt32 = 0

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -121,11 +121,11 @@ public extension AudioDevice {
     struct FixedLatency {
         public internal(set) var stream: UInt32 = 0
         public internal(set) var device: UInt32 = 0
-        public internal(set) var safeteyOffset: UInt32 = 0
+        public internal(set) var safetyOffset: UInt32 = 0
         public internal(set) var bufferFrameSize: UInt32 = 0
 
         public var totalFrames: UInt32 {
-            stream + device + safeteyOffset + bufferFrameSize
+            stream + device + safetyOffset + bufferFrameSize
         }
     }
 
@@ -149,11 +149,8 @@ public extension AudioDevice {
         }
 
         if let frames = safetyOffset(scope: scope) {
-            object.safeteyOffset = frames
+            object.safetyOffset = frames
         }
-
-        // kAudioDevicePropertyBufferFrameSize
-        // kAudioDevicePropertyBufferFrameSizeRange
 
         if let frames = bufferFrameSize(scope: scope) {
             object.bufferFrameSize = frames

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -97,7 +97,7 @@ public extension AudioDevice {
         // kAudioDevicePropertyBufferFrameSizeRange
 
         if let frames = bufferFrameSize(scope: scope) {
-            object.bufferFrameSize = frames // * 2
+            object.bufferFrameSize = frames
         }
 
         return object

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -78,13 +78,16 @@ public extension AudioDevice {
         guard noErr == status,
               let firstRange = ranges.first else { return nil }
 
-        let possibleBufferSizes: [UInt32] = [32, 64, 128, 256, 512, 1024, 2048, 4096]
+        // limit it to these
+        let possibleBufferSizes: [UInt32] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
 
         guard let lowerBound = possibleBufferSizes.first,
               let upperBound = possibleBufferSizes.last else { return nil }
 
         let startValue = UInt32(firstRange.mMinimum + 15) & ~15
-        bufferSizes.append(startValue)
+        if !bufferSizes.contains(startValue) {
+            bufferSizes.append(startValue)
+        }
 
         var size: UInt32 = startValue <= lowerBound ? startValue : lowerBound
 

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -33,7 +33,7 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
-   
+
     /// The current size of the IO Buffer
     ///
     /// - Parameter scope: A scope.
@@ -44,5 +44,12 @@ public extension AudioDevice {
                                          scope: scope.asPropertyScope) else { return nil }
 
         return getProperty(address: address)
+    }
+
+    @discardableResult func setBufferFrameSize(_ frameSize: UInt32, scope: Scope) -> Bool {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
+                                         scope: scope.asPropertyScope) else { return false }
+
+        return setProperty(address: address, value: frameSize)
     }
 }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -66,7 +66,7 @@ public extension AudioDevice {
     ///
     /// - Parameter scope: A scope.
     ///
-    /// - Returns: An array of common buffer sizes within the defined range
+    /// - Returns: An array of common buffer sizes within the defined range such as 32 ... 1024
     func bufferFrameSizeRange(scope: Scope) -> [UInt32]? {
         guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSizeRange,
                                          scope: kAudioObjectPropertyScopeWildcard) else { return nil }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -70,13 +70,13 @@ public extension AudioDevice {
      kAudioDevicePropertyLatency
      kAudioDevicePropertyBufferFrameSize
      */
-    public struct FixedLatency {
-        var streamFrames: UInt32 = 0
-        var deviceFrames: UInt32 = 0
-        var safeteyOffsetFrames: UInt32 = 0
-        var bufferFrameSizeFrames: UInt32 = 0
+    struct FixedLatency {
+        public var streamFrames: UInt32 = 0
+        public var deviceFrames: UInt32 = 0
+        public var safeteyOffsetFrames: UInt32 = 0
+        public var bufferFrameSizeFrames: UInt32 = 0
 
-        var totalFrames: UInt32 {
+        public var totalFrames: UInt32 {
             streamFrames + deviceFrames + safeteyOffsetFrames + bufferFrameSizeFrames
         }
     }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -45,11 +45,4 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
-
-    @discardableResult func setBufferFrameSize(_ frameSize: UInt32, scope: Scope) -> Bool {
-        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
-                                         scope: scope.asPropertyScope) else { return false }
-
-        return setProperty(address: address, value: frameSize)
-    }
 }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -6,6 +6,7 @@
 
 import CoreAudio
 import Foundation
+import os.log
 
 // MARK: - ↹ Latency Functions
 
@@ -46,6 +47,12 @@ public extension AudioDevice {
         return getProperty(address: address)
     }
 
+    /// Set the current size of the IO Buffer
+    ///
+    /// - Parameter frameSize: A valid buffer size.
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: `true` on success, `false` otherwise.
     @discardableResult
     func setBufferFrameSize(_ frameSize: UInt32, scope: Scope) -> Bool {
         guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
@@ -53,44 +60,93 @@ public extension AudioDevice {
 
         return setProperty(address: address, value: frameSize)
     }
+
+    /// A common array of UIInt32 values representing the available
+    /// IO buffer size options for the AudioStream containing the given element.
+    ///
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: An array of common buffer sizes within the defined range
+    func bufferFrameSizeRange(scope: Scope) -> [UInt32]? {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSizeRange,
+                                         scope: kAudioObjectPropertyScopeWildcard) else { return nil }
+
+        var bufferSizes = [UInt32]()
+        var ranges = [AudioValueRange]()
+        let status = getPropertyDataArray(address, value: &ranges, andDefaultValue: AudioValueRange())
+
+        guard noErr == status,
+              let firstRange = ranges.first else { return nil }
+
+        let possibleBufferSizes: [UInt32] = [32, 64, 128, 256, 512, 1024, 2048, 4096]
+
+        guard let lowerBound = possibleBufferSizes.first,
+              let upperBound = possibleBufferSizes.last else { return nil }
+
+        let startValue = UInt32(firstRange.mMinimum + 15) & ~15
+        bufferSizes.append(startValue)
+
+        var size: UInt32 = startValue <= lowerBound ? startValue : lowerBound
+
+        while size <= upperBound {
+            // OSLog.debug(size)
+
+            for range in ranges {
+                let min = UInt32(range.mMinimum)
+                let max = UInt32(range.mMaximum)
+
+                if size >= min && size <= max &&
+                    possibleBufferSizes.contains(size) &&
+                    !bufferSizes.contains(size) {
+                    bufferSizes.append(size)
+                }
+            }
+            size *= 2
+        }
+
+        return bufferSizes.sorted()
+    }
 }
 
 public extension AudioDevice {
-    /**
-     Calculate the fixed latency from the system and the device.
-
-     The latency for a stream on a device is determined by the sum of the following properties:
-         kAudioDevicePropertySafetyOffset
-         kAudioStreamPropertyLatency
-         kAudioDevicePropertyLatency
-         kAudioDevicePropertyBufferFrameSize
-     */
+    /// The latency for a stream on a device is determined by the **sum** of the following properties:
+    ///
+    /// * kAudioDevicePropertySafetyOffset
+    /// * kAudioStreamPropertyLatency
+    /// * kAudioDevicePropertyLatency
+    /// * kAudioDevicePropertyBufferFrameSize
     struct FixedLatency {
-        public internal(set) var streamFrames: UInt32 = 0
-        public internal(set) var deviceFrames: UInt32 = 0
-        public internal(set) var safeteyOffsetFrames: UInt32 = 0
+        public internal(set) var stream: UInt32 = 0
+        public internal(set) var device: UInt32 = 0
+        public internal(set) var safeteyOffset: UInt32 = 0
         public internal(set) var bufferFrameSize: UInt32 = 0
 
         public var totalFrames: UInt32 {
-            streamFrames + deviceFrames + safeteyOffsetFrames + bufferFrameSize
+            stream + device + safeteyOffset + bufferFrameSize
         }
     }
 
+    /// Calculates the fixed latency from the system and the device
+    ///
+    /// - Parameter scope: A scope.
+    /// - Returns: A `FixedLatency` struct with the latencies in the device.
+    /// For the total samples of latency use the `totalFrames` property
     func fixedLatency(scope: Scope) -> FixedLatency {
         var object = FixedLatency()
 
         if let allStreams = streams(scope: scope) {
             // sum all of them or just take the first stream?
+            // it only ever seems to return 1 stream
             let frames = allStreams.compactMap { $0.latency }
-            object.streamFrames = frames.reduce(0, +)
+            object.stream = frames.reduce(0, +)
         }
 
         if let frames = latency(scope: scope) {
-            object.deviceFrames = frames
+            object.device = frames
         }
 
         if let frames = safetyOffset(scope: scope) {
-            object.safeteyOffsetFrames = frames
+            object.safeteyOffset = frames
         }
 
         // kAudioDevicePropertyBufferFrameSize
@@ -103,8 +159,21 @@ public extension AudioDevice {
         return object
     }
 
+    /// [PresentationLatency]:
+    /// https://developer.apple.com/documentation/avfaudio/avaudioionode/1385631-presentationlatency "PresentationLatency"
+    ///
+    /// Convenience function to return the total device latency in seconds.
+    ///
+    /// See: [PresentationLatency]
+    ///
+    ///  - Parameter scope: A scope.
+    /// - Returns: The total summed latency in seconds based on the device's
+    /// current sample rate
     func presentationLatency(scope: Scope) -> TimeInterval? {
-        guard let sampleRate = actualSampleRate else { return nil }
+        guard let sampleRate = actualSampleRate else {
+            OSLog.error("Unable to get actualSampleRate from device")
+            return nil
+        }
 
         let object = fixedLatency(scope: scope)
         return TimeInterval(object.totalFrames) / sampleRate

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Samplerate.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Samplerate.swift
@@ -46,7 +46,7 @@ public extension AudioDevice {
             6400, 8000, 11025, 12000,
             16000, 22050, 24000, 32000,
             44100, 48000, 64000, 88200,
-            96000, 128_000, 176_400, 192_000
+            96000, 128000, 176400, 192000,
         ]
 
         for valueRange in valueRanges {
@@ -56,11 +56,10 @@ public extension AudioDevice {
                 // This could be a headset audio device (i.e., CS50/CS60-USB Headset)
                 // or a virtual audio driver (i.e., "System Audio Recorder" by WonderShare AllMyMusic)
                 if let startIndex = possibleRates.firstIndex(of: valueRange.mMinimum),
-                   let endIndex = possibleRates.firstIndex(of: valueRange.mMaximum)
-                {
-                    sampleRates += possibleRates[startIndex..<endIndex + 1]
+                   let endIndex = possibleRates.firstIndex(of: valueRange.mMaximum) {
+                    sampleRates += possibleRates[startIndex ..< endIndex + 1]
                 } else {
-                    os_log("Failed to obtain list of supported sample rates ranging from %f to %f. This is an error in SimplyCoreAudio and should be reported to the project maintainers.", log: .default, type: .debug, valueRange.mMinimum, valueRange.mMaximum)
+                    OSLog.error("Failed to obtain list of supported sample rates ranging from \(valueRange.mMinimum) to \(valueRange.mMaximum). This is an error in SimplyCoreAudio and should be reported to the project maintainers")
                 }
             } else {
                 // We did not get a range (this should be the most common case)

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -133,7 +133,7 @@ private extension AudioDevice {
         )
 
         if noErr != AudioObjectAddPropertyListener(id, &address, propertyListener, nil) {
-            os_log("Unable to add property listener for %@.", description)
+            OSLog.error("Unable to add property listener for", description)
         } else {
             isRegisteredForNotifications = true
         }
@@ -149,7 +149,7 @@ private extension AudioDevice {
         )
 
         if noErr != AudioObjectRemovePropertyListener(id, &address, propertyListener, nil) {
-            os_log("Unable to remove property listener for %@.", description)
+            OSLog.error("Unable to remove property listener for", description)
         } else {
             isRegisteredForNotifications = false
         }
@@ -191,14 +191,14 @@ private func propertyListener(objectID: UInt32,
     case kAudioDevicePropertyVolumeScalar:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope) ?? .global,
+            "scope": Scope.from(address.mScope),
         ]
 
         notificationCenter.post(name: .deviceVolumeDidChange, object: obj, userInfo: userInfo)
     case kAudioDevicePropertyMute:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope) ?? .global,
+            "scope": Scope.from(address.mScope),
         ]
 
         notificationCenter.post(name: .deviceMuteDidChange, object: obj, userInfo: userInfo)

--- a/Sources/SimplyCoreAudio/Public/AudioStream.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioStream.swift
@@ -37,7 +37,7 @@ public final class AudioStream: AudioObject {
         guard let address = validAddress(selector: kAudioStreamPropertyStartingChannel) else { return nil }
 
         var startingChannel: UInt32 = 0
-        guard noErr == self.getPropertyData(address, andValue: &startingChannel) else { return nil }
+        guard noErr == getPropertyData(address, andValue: &startingChannel) else { return nil }
 
         return startingChannel
     }
@@ -107,7 +107,7 @@ public final class AudioStream: AudioObject {
             var asbd = newValue
 
             if noErr == setStreamPropertyData(kAudioStreamPropertyPhysicalFormat, andValue: &asbd) {
-                os_log("Error setting physicalFormat to %@.", log: .default, type: .debug, String(describing: newValue))
+                OSLog.error("Error setting physicalFormat to", newValue)
             }
         }
     }
@@ -129,7 +129,7 @@ public final class AudioStream: AudioObject {
             var asbd = newValue
 
             if noErr == setStreamPropertyData(kAudioStreamPropertyVirtualFormat, andValue: &asbd) {
-                os_log("Error setting virtualFormat to %@.", log: .default, type: .debug, String(describing: newValue))
+                OSLog.error("Error setting virtualFormat to", newValue)
             }
         }
     }
@@ -334,7 +334,7 @@ private extension AudioStream {
         )
 
         if noErr != AudioObjectAddPropertyListener(id, &address, propertyListener, nil) {
-            os_log("Unable to add property listener for %@.", description)
+            OSLog.error("Unable to add property listener for", description)
         } else {
             isRegisteredForNotifications = true
         }
@@ -350,7 +350,7 @@ private extension AudioStream {
         )
 
         if noErr != AudioObjectRemovePropertyListener(id, &address, propertyListener, nil) {
-            os_log("Unable to add property listener for %@.", description)
+            OSLog.error("Unable to remove property listener for", description)
         } else {
             isRegisteredForNotifications = true
         }
@@ -370,7 +370,7 @@ extension AudioStream: CustomStringConvertible {
 
 private func propertyListener(objectID: UInt32,
                               numInAddresses: UInt32,
-                              inAddresses : UnsafePointer<AudioObjectPropertyAddress>,
+                              inAddresses: UnsafePointer<AudioObjectPropertyAddress>,
                               clientData: Optional<UnsafeMutableRawPointer>) -> Int32 {
     // Try to get audio object from the pool.
     guard let obj: AudioStream = AudioObjectPool.shared.get(objectID) else { return kAudioHardwareBadObjectError }

--- a/Sources/SimplyCoreAudio/Public/SimplyCoreAudio+Aggregate.swift
+++ b/Sources/SimplyCoreAudio/Public/SimplyCoreAudio+Aggregate.swift
@@ -1,6 +1,6 @@
 //
 //  SimplyCoreAudio+Aggregate.swift
-//  
+//
 //
 //  Created by Ruben Nine on 4/4/21.
 //
@@ -26,7 +26,7 @@ public extension SimplyCoreAudio {
         guard let masterDeviceUID = masterDevice.uid else { return nil }
 
         var deviceList: [[String: Any]] = [
-            [kAudioSubDeviceUIDKey: masterDeviceUID]
+            [kAudioSubDeviceUIDKey: masterDeviceUID],
         ]
 
         // make sure same device isn't added twice
@@ -38,14 +38,14 @@ public extension SimplyCoreAudio {
             kAudioAggregateDeviceNameKey: name,
             kAudioAggregateDeviceUIDKey: uid,
             kAudioAggregateDeviceSubDeviceListKey: deviceList,
-            kAudioAggregateDeviceMasterSubDeviceKey: masterDeviceUID
+            kAudioAggregateDeviceMasterSubDeviceKey: masterDeviceUID,
         ]
 
         var deviceID: AudioDeviceID = 0
         let error = AudioHardwareCreateAggregateDevice(desc as CFDictionary, &deviceID)
 
         guard error == noErr else {
-            os_log("Failed creating aggregate device with error: %d.", log: .default, type: .debug, error)
+            OSLog.error("Failed creating aggregate device with error:", error)
             return nil
         }
 

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
@@ -41,17 +41,6 @@ extension AudioDeviceTests {
             guard let string = info(for: device) else { continue }
             Swift.print("\(i + 1)", string)
         }
-
-        Swift.print("\nChanged to bufferSize of 32:\n")
-
-        for i in 0 ..< devices.count {
-            let device = devices[i]
-            device.setBufferFrameSize(32, scope: .input)
-            device.setBufferFrameSize(32, scope: .output)
-
-            guard let string = info(for: device) else { continue }
-            Swift.print("\(i + 1)", string)
-        }
     }
 
     func info(for device: AudioDevice) -> String? {
@@ -113,6 +102,8 @@ extension AudioDeviceTests {
                   indent, "Output", outputLatency, "Total Frames", outputLatency.totalFrames, "\n",
                   indent, "Resulting Output Latency is \(outputPresentationLatency * 1000)ms",
                   "\n"]
+        
+        items += [indent, "Buffer Sizes Range", device.bufferFrameSizeRange(scope: .input)]
 
         let content = (items.map {
             String(describing: $0 ?? "nil")

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+extension AudioDeviceTests {
+    func testLatency() throws {
+        let device = try getNullDevice()
+
+        XCTAssertEqual(device.latency(scope: .output), 0)
+        XCTAssertEqual(device.latency(scope: .input), 0)
+    }
+
+    func testSafetyOffset() throws {
+        let device = try getNullDevice()
+
+        XCTAssertEqual(device.safetyOffset(scope: .output), 0)
+        XCTAssertEqual(device.safetyOffset(scope: .input), 0)
+    }
+
+    func testBufferFrameSize() throws {
+        let device = try getNullDevice()
+
+        // not sure why this is 512 by default?
+        XCTAssertEqual(device.bufferFrameSize(scope: .output), 512)
+        XCTAssertEqual(device.bufferFrameSize(scope: .input), 512)
+
+        XCTAssertTrue(device.setBufferFrameSize(256, scope: .output))
+        XCTAssertTrue(device.setBufferFrameSize(256, scope: .input))
+
+        XCTAssertEqual(device.bufferFrameSize(scope: .output), 256)
+        XCTAssertEqual(device.bufferFrameSize(scope: .input), 256)
+    }
+}

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
@@ -1,3 +1,4 @@
+@testable import SimplyCoreAudio
 import XCTest
 
 extension AudioDeviceTests {
@@ -18,7 +19,7 @@ extension AudioDeviceTests {
     func testBufferFrameSize() throws {
         let device = try getNullDevice()
 
-        // not sure why this is 512 by default?
+        // 512 is the default buffer size
         XCTAssertEqual(device.bufferFrameSize(scope: .output), 512)
         XCTAssertEqual(device.bufferFrameSize(scope: .input), 512)
 
@@ -27,5 +28,95 @@ extension AudioDeviceTests {
 
         XCTAssertEqual(device.bufferFrameSize(scope: .output), 256)
         XCTAssertEqual(device.bufferFrameSize(scope: .input), 256)
+    }
+
+    func testLatencyOnInstalledDevices() {
+        let devices = simplyCA.allDevices.sorted { (lhs, rhs) -> Bool in
+            lhs.name < rhs.name
+        }
+
+        Swift.print("\nAll Devices on the system with default settings:\n")
+        for i in 0 ..< devices.count {
+            let device = devices[i]
+            guard let string = info(for: device) else { continue }
+            Swift.print("\(i + 1)", string)
+        }
+
+        Swift.print("\nChanged to bufferSize of 32:\n")
+
+        for i in 0 ..< devices.count {
+            let device = devices[i]
+            device.setBufferFrameSize(32, scope: .input)
+            device.setBufferFrameSize(32, scope: .output)
+
+            guard let string = info(for: device) else { continue }
+            Swift.print("\(i + 1)", string)
+        }
+    }
+
+    func info(for device: AudioDevice) -> String? {
+        let indent = "    "
+        let isDefaultDevice = device == simplyCA.defaultInputDevice || device == simplyCA.defaultOutputDevice
+        let isSystemOutputDevice = device == simplyCA.defaultSystemOutputDevice
+
+        let aggregateIcon = device.isAggregateDevice ? "👥 (Aggregate Device) " : ""
+
+        var directionIcon = "🎧+🎤"
+
+        if device.isInputOnlyDevice {
+            directionIcon = "🎤"
+        } else if device.isOutputOnlyDevice {
+            directionIcon = "🎧"
+        }
+
+        let selectedIcon = isDefaultDevice ? "👉" : ""
+        let systemIcon = isSystemOutputDevice ? "🔊" : ""
+
+        guard let sampleRate = device.actualSampleRate else {
+            XCTFail("Unable to determine sample rate for device")
+            return nil
+        }
+
+        // title
+        var items: [Any?] = ["\(systemIcon)\(aggregateIcon)\(directionIcon)\(selectedIcon)",
+                             device.name + " (\(device.id)) UID:", device.uid,
+                             "sampleRate:", sampleRate,
+                             "\n"]
+
+        if let aggregateInputs = device.ownedAggregateInputDevices,
+           let aggregateOutputs = device.ownedAggregateOutputDevices {
+            if !aggregateInputs.isEmpty {
+                let inputString = aggregateInputs.map { "🎤 " + $0.name + " (\($0.id)) UID:" + ($0.uid ?? "nil") }
+                items += [indent, "👥 Inputs: ", inputString, "\n"]
+            }
+
+            if !aggregateOutputs.isEmpty {
+                let outputString = aggregateOutputs.map { "🎧 " + $0.name + " (\($0.id)) UID:" + ($0.uid ?? "nil") }
+                items += [indent, "👥 Outputs", outputString, "\n"]
+            }
+        }
+        let inputLatency = device.fixedLatency(scope: .input)
+        guard let inputPresentationLatency = device.presentationLatency(scope: .input) else {
+            XCTFail("Failed to get presentation latency for input")
+            return nil
+        }
+
+        let outputLatency = device.fixedLatency(scope: .output)
+        guard let outputPresentationLatency = device.presentationLatency(scope: .output) else {
+            XCTFail("Failed to get presentation latency for output")
+            return nil
+        }
+
+        items += [indent, "Input", inputLatency, "Total Frames", inputLatency.totalFrames, "\n",
+                  indent, "Resulting Latency is \(inputPresentationLatency * 1000)ms",
+                  "\n",
+                  indent, "Output", outputLatency, "Total Frames", outputLatency.totalFrames, "\n",
+                  indent, "Resulting Latency is \(outputPresentationLatency * 1000)ms",
+                  "\n"]
+
+        let content = (items.map {
+            String(describing: $0 ?? "nil")
+        }).joined(separator: " ")
+        return content
     }
 }

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
@@ -35,7 +35,7 @@ extension AudioDeviceTests {
             lhs.name < rhs.name
         }
 
-        Swift.print("\nAll Devices on the system with default settings:\n")
+        Swift.print("\nAll Devices:\n")
         for i in 0 ..< devices.count {
             let device = devices[i]
             guard let string = info(for: device) else { continue }
@@ -97,12 +97,12 @@ extension AudioDeviceTests {
         }
 
         items += [indent, "Input", inputLatency, "Total Frames", inputLatency.totalFrames, "\n",
-                  indent, "Resulting Input Latency is \(inputPresentationLatency * 1000)ms",
+                  indent, "Resulting Input Latency is \(inputPresentationLatency * 1000) ms",
                   "\n",
                   indent, "Output", outputLatency, "Total Frames", outputLatency.totalFrames, "\n",
-                  indent, "Resulting Output Latency is \(outputPresentationLatency * 1000)ms",
+                  indent, "Resulting Output Latency is \(outputPresentationLatency * 1000) ms",
                   "\n"]
-        
+
         items += [indent, "Buffer Sizes Range", device.bufferFrameSizeRange(scope: .input)]
 
         let content = (items.map {

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests+Latency.swift
@@ -108,10 +108,10 @@ extension AudioDeviceTests {
         }
 
         items += [indent, "Input", inputLatency, "Total Frames", inputLatency.totalFrames, "\n",
-                  indent, "Resulting Latency is \(inputPresentationLatency * 1000)ms",
+                  indent, "Resulting Input Latency is \(inputPresentationLatency * 1000)ms",
                   "\n",
                   indent, "Output", outputLatency, "Total Frames", outputLatency.totalFrames, "\n",
-                  indent, "Resulting Latency is \(outputPresentationLatency * 1000)ms",
+                  indent, "Resulting Output Latency is \(outputPresentationLatency * 1000)ms",
                   "\n"]
 
         let content = (items.map {

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -356,20 +356,6 @@ final class AudioDeviceTests: SCATestCase {
         XCTAssertFalse(device.setClockSourceID(0))
     }
 
-    func testLatency() throws {
-        let device = try getNullDevice()
-
-        XCTAssertEqual(device.latency(scope: .output), 0)
-        XCTAssertEqual(device.latency(scope: .input), 0)
-    }
-
-    func testSafetyOffset() throws {
-        let device = try getNullDevice()
-
-        XCTAssertEqual(device.safetyOffset(scope: .output), 0)
-        XCTAssertEqual(device.safetyOffset(scope: .input), 0)
-    }
-
     func testHogMode() throws {
         let device = try getNullDevice()
 
@@ -436,7 +422,7 @@ final class AudioDeviceTests: SCATestCase {
         let result3: Float64? = device.getProperty(address: address)
         let result4: String? = device.getProperty(address: address)
         let result5: Bool? = device.getProperty(address: address)
-        
+
         // all should be nil
         XCTAssertNil(result1)
         XCTAssertNil(result2)

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import CoreAudio
 @testable import SimplyCoreAudio
+import XCTest
 
 final class AudioDeviceTests: SCATestCase {
     func testDeviceLookUp() throws {
@@ -275,17 +276,17 @@ final class AudioDeviceTests: SCATestCase {
 
         XCTAssertTrue(device.setVirtualMasterVolume(0.0, scope: .output))
         XCTAssertEqual(device.virtualMasterVolume(scope: .output), 0.0)
-        //XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .output), -96.0)
+        // XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .output), -96.0)
         XCTAssertTrue(device.setVirtualMasterVolume(0.5, scope: .output))
         XCTAssertEqual(device.virtualMasterVolume(scope: .output), 0.5)
-        //XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .output), -70.5)
+        // XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .output), -70.5)
 
         XCTAssertTrue(device.setVirtualMasterVolume(0.0, scope: .input))
         XCTAssertEqual(device.virtualMasterVolume(scope: .input), 0.0)
-        //XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .input), -96.0)
+        // XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .input), -96.0)
         XCTAssertTrue(device.setVirtualMasterVolume(0.5, scope: .input))
         XCTAssertEqual(device.virtualMasterVolume(scope: .input), 0.5)
-        //XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .input), -70.5)
+        // XCTAssertEqual(device.virtualMasterVolumeInDecibels(scope: .input), -70.5)
     }
 
     func testVirtualMasterBalance() throws {
@@ -417,5 +418,30 @@ final class AudioDeviceTests: SCATestCase {
         XCTAssertTrue(error == noErr, "Failed removing device")
 
         wait(for: 2)
+    }
+
+    func testInvalidDeviceProperties() throws {
+        let device = try getNullDevice()
+
+        // 0 seems like a safe bet for an invalid property
+        let address = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(0),
+            mScope: AudioObjectPropertyScope(0),
+            mElement: AudioObjectPropertyScope(0)
+        )
+
+        // Just testing these fail gracefully and spit out a friendly error message
+        let result1: UInt32? = device.getProperty(address: address)
+        let result2: Float32? = device.getProperty(address: address)
+        let result3: Float64? = device.getProperty(address: address)
+        let result4: String? = device.getProperty(address: address)
+        let result5: Bool? = device.getProperty(address: address)
+        
+        // all should be nil
+        XCTAssertNil(result1)
+        XCTAssertNil(result2)
+        XCTAssertNil(result3)
+        XCTAssertNil(result4)
+        XCTAssertNil(result5)
     }
 }

--- a/Tests/SimplyCoreAudioTests/SimplyCoreAudioTests.swift
+++ b/Tests/SimplyCoreAudioTests/SimplyCoreAudioTests.swift
@@ -4,8 +4,10 @@
 //  Created by Ruben Nine on 20/3/21.
 //
 
-import XCTest
+import CoreAudio
+import os.log
 @testable import SimplyCoreAudio
+import XCTest
 
 class SimplyCoreAudioTests: SCATestCase {
     func testDeviceEnumeration() throws {
@@ -18,5 +20,37 @@ class SimplyCoreAudioTests: SCATestCase {
         XCTAssertTrue(simplyCA.allIODevices.contains(device))
         XCTAssertTrue(simplyCA.allNonAggregateDevices.contains(device))
         XCTAssertFalse(simplyCA.allAggregateDevices.contains(device))
+    }
+
+    func testLogs() {
+        OSLog.error("⚠️", "☢️", "🛑", nil)
+        OSLog.debug("🐞", "🐛", "🐜", nil)
+    }
+
+    func testInvalidProperties() throws {
+        let device = try getNullDevice()
+
+        let address = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(0),
+            mScope: AudioObjectPropertyScope(0),
+            mElement: AudioObjectPropertyScope(0)
+        )
+
+        // Just testing these fail gracefully and spit out a friendly error message
+
+        let result1: UInt32? = device.getProperty(address: address)
+        XCTAssertNil(result1)
+
+        let result2: Float32? = device.getProperty(address: address)
+        XCTAssertNil(result2)
+
+        let result3: Float64? = device.getProperty(address: address)
+        XCTAssertNil(result3)
+
+        let result4: String? = device.getProperty(address: address)
+        XCTAssertNil(result4)
+
+        let result5: Bool? = device.getProperty(address: address)
+        XCTAssertNil(result5)
     }
 }

--- a/Tests/SimplyCoreAudioTests/SimplyCoreAudioTests.swift
+++ b/Tests/SimplyCoreAudioTests/SimplyCoreAudioTests.swift
@@ -4,7 +4,6 @@
 //  Created by Ruben Nine on 20/3/21.
 //
 
-import CoreAudio
 import os.log
 @testable import SimplyCoreAudio
 import XCTest
@@ -25,32 +24,5 @@ class SimplyCoreAudioTests: SCATestCase {
     func testLogs() {
         OSLog.error("⚠️", "☢️", "🛑", nil)
         OSLog.debug("🐞", "🐛", "🐜", nil)
-    }
-
-    func testInvalidProperties() throws {
-        let device = try getNullDevice()
-
-        let address = AudioObjectPropertyAddress(
-            mSelector: AudioObjectPropertySelector(0),
-            mScope: AudioObjectPropertyScope(0),
-            mElement: AudioObjectPropertyScope(0)
-        )
-
-        // Just testing these fail gracefully and spit out a friendly error message
-
-        let result1: UInt32? = device.getProperty(address: address)
-        XCTAssertNil(result1)
-
-        let result2: Float32? = device.getProperty(address: address)
-        XCTAssertNil(result2)
-
-        let result3: Float64? = device.getProperty(address: address)
-        XCTAssertNil(result3)
-
-        let result4: String? = device.getProperty(address: address)
-        XCTAssertNil(result4)
-
-        let result5: Bool? = device.getProperty(address: address)
-        XCTAssertNil(result5)
     }
 }


### PR DESCRIPTION
Would love a sanity check that these buffer size calculations look right to you. The values seem to be good, but I don't want to clutter up your framework with these things if you don't want them in there.

In particular the Latency for devices is a bit convoluted and I've tried to make some sort of sense of them. Please let me know if something is weird, and no obligation to incorporate these things.

On my end I'm figuring out how to accommodate device latency for recording. I snooped around a fair bit and found some examples of this summing, in particular in Port Audio and Juce, but maybe you already know the best way to handle this?

One of the better examples I saw was this answer: https://stackoverflow.com/questions/65600996/avaudioengine-reconcile-sync-input-output-timestamps-on-macos-ios

For the logging, again, that's sort of a style question, so you might not like that. I can remove if you prefer the os_log syntax.

This is how I generally log stuff so i can easily see errors vs debug statements and get a bit more info on each message and where it originated.