### PR TITLE
Buffer Frame Sizes

### DIFF
--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -33,7 +33,7 @@ public extension AudioDevice {
 
         return getProperty(address: address)
     }
-   
+
     /// The current size of the IO Buffer
     ///
     /// - Parameter scope: A scope.
@@ -44,5 +44,68 @@ public extension AudioDevice {
                                          scope: scope.asPropertyScope) else { return nil }
 
         return getProperty(address: address)
+    }
+
+    /// Set the current size of the IO Buffer
+    ///
+    /// - Parameter frameSize: A valid buffer size.
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: `true` on success, `false` otherwise.
+    @discardableResult
+    func setBufferFrameSize(_ frameSize: UInt32, scope: Scope) -> Bool {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSize,
+                                         scope: scope.asPropertyScope) else { return false }
+
+        return setProperty(address: address, value: frameSize)
+    }
+
+    /// A common array of UInt32 values representing the available
+    /// IO buffer size options for the AudioStream containing the given element.
+    ///
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: An array of common buffer sizes within the defined range such as 32 ... 1024
+    func bufferFrameSizeRange(scope: Scope) -> [UInt32]? {
+        guard let address = validAddress(selector: kAudioDevicePropertyBufferFrameSizeRange,
+                                         scope: kAudioObjectPropertyScopeWildcard) else { return nil }
+
+        var bufferSizes = [UInt32]()
+        var ranges = [AudioValueRange]()
+        let status = getPropertyDataArray(address, value: &ranges, andDefaultValue: AudioValueRange())
+
+        guard noErr == status,
+              let firstRange = ranges.first else { return nil }
+
+        // limit it to these
+        let possibleBufferSizes: [UInt32] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+
+        guard let lowerBound = possibleBufferSizes.first,
+              let upperBound = possibleBufferSizes.last else { return nil }
+
+        let startValue = UInt32(firstRange.mMinimum + 15) & ~15
+        if !bufferSizes.contains(startValue) {
+            bufferSizes.append(startValue)
+        }
+
+        var size: UInt32 = startValue <= lowerBound ? startValue : lowerBound
+
+        while size <= upperBound {
+            // OSLog.debug(size)
+
+            for range in ranges {
+                let min = UInt32(range.mMinimum)
+                let max = UInt32(range.mMaximum)
+
+                if size >= min && size <= max &&
+                    possibleBufferSizes.contains(size) &&
+                    !bufferSizes.contains(size) {
+                    bufferSizes.append(size)
+                }
+            }
+            size *= 2
+        }
+
+        return bufferSizes.sorted()
     }
 }

--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -77,7 +77,7 @@ public extension AudioDevice {
         guard noErr == status,
               let firstRange = ranges.first else { return nil }
 
-        // limit it to these
+        // limit it to these common sizes
         let possibleBufferSizes: [UInt32] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
 
         guard let lowerBound = possibleBufferSizes.first,
@@ -91,8 +91,6 @@ public extension AudioDevice {
         var size: UInt32 = startValue <= lowerBound ? startValue : lowerBound
 
         while size <= upperBound {
-            // OSLog.debug(size)
-
             for range in ranges {
                 let min = UInt32(range.mMinimum)
                 let max = UInt32(range.mMaximum)

--- a/Sources/SimplyCoreAudio/Public/AudioDevice.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice.swift
@@ -191,14 +191,14 @@ private func propertyListener(objectID: UInt32,
     case kAudioDevicePropertyVolumeScalar:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope) ?? .global,
+            "scope": Scope.from(address.mScope),
         ]
 
         notificationCenter.post(name: .deviceVolumeDidChange, object: obj, userInfo: userInfo)
     case kAudioDevicePropertyMute:
         let userInfo: [AnyHashable: Any] = [
             "channel": address.mElement,
-            "scope": Scope.from(address.mScope) ?? .global,
+            "scope": Scope.from(address.mScope),
         ]
 
         notificationCenter.post(name: .deviceMuteDidChange, object: obj, userInfo: userInfo)


### PR DESCRIPTION
Much more minimal PR than what I suggested previously. This just adds the buffer frame size functions and removes the summed latency calculations I suggested before. I've moved that code into my own stuff, so this isn't very invasive to the framework.