### PR TITLE
Provide default value for bundleIdentifier, fixes #49

### DIFF
--- a/Sources/SimplyCoreAudio/Internal/AudioObjectPool.swift
+++ b/Sources/SimplyCoreAudio/Internal/AudioObjectPool.swift
@@ -10,7 +10,7 @@ class AudioObjectPool {
     // MARK: - Private Properties
 
     private let pool: NSMapTable<NSNumber, AudioObject> = NSMapTable.weakToWeakObjects()
-    private lazy var queueLabel = Bundle.main.bundleIdentifier!.appending(".audioObjectPool")
+    private lazy var queueLabel = (Bundle.main.bundleIdentifier ?? "SimplyCoreAudio").appending(".audioObjectPool")
     private lazy var queue = DispatchQueue(label: queueLabel, qos: .default, attributes: .concurrent)
 
     // MARK: - Static Properties

--- a/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/OSLog+Default.swift
@@ -8,7 +8,7 @@ import Foundation
 import os.log
 
 extension OSLog {
-    private static let subsystem = Bundle.main.bundleIdentifier!
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "SimplyCoreAudio"
 
     /// Default logger.
     static let `default` = OSLog(subsystem: subsystem, category: "default")


### PR DESCRIPTION
Command line executables don't have bundleIdentifiers, if it is nil, provide a default string instead.