### PR TITLE
Updates to latency functions

### DIFF
--- a/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+Latency.swift
@@ -1,21 +1,80 @@
-//
-//  AudioDevice+Latency.swift
-//
-//  Created by Ruben Nine on 20/3/21.
-//
+// Copyright SimplyCoreAudio. All Rights Reserved. Revision History at https://github.com/rnine/SimplyCoreAudio
 
 import CoreAudio
 import Foundation
+import os.log
 
 // MARK: - ↹ Latency Functions
 
 public extension AudioDevice {
+    /// Convenience function to return the total latency in frames of an AudioDevice
+    ///
+    /// The latency for a scope is determined by the **sum** of the following properties:
+    ///
+    /// * kAudioDevicePropertySafetyOffset
+    /// * kAudioStreamPropertyLatency
+    /// * kAudioDevicePropertyLatency
+    /// * kAudioDevicePropertyBufferFrameSize
+    ///
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: A `UInt32` value with the total frames of latency in the device.
+    ///
+    func latency(scope: Scope) -> UInt32 {
+        var sum: UInt32 = 0
+
+        if let allStreams = streams(scope: scope) {
+            // sum all of them or just take the first stream?
+            // it only ever seems to return 1 stream
+            let frames = allStreams.compactMap { $0.latency }
+            sum = frames.reduce(0, +)
+        }
+
+        if let frames = deviceLatency(scope: scope) {
+            sum += frames
+        }
+
+        if let frames = safetyOffset(scope: scope) {
+            sum += frames
+        }
+
+        if let frames = bufferFrameSize(scope: scope) {
+            sum += frames
+        }
+
+        return sum
+    }
+
+    /// [PresentationLatency]:
+    /// https://developer.apple.com/documentation/avfaudio/avaudioionode/1385631-presentationlatency "PresentationLatency"
+    ///
+    /// Convenience function to return the total latency in seconds.
+    ///
+    /// See: [PresentationLatency]
+    ///
+    ///  - Parameter scope: A scope.
+    ///
+    /// - Returns: *(optional)* The total summed latency in seconds based on the device's
+    /// current sample rate or nil if the sample rate wasn't determined.
+    func presentationLatency(scope: Scope) -> TimeInterval? {
+        guard let sampleRate = actualSampleRate else {
+            os_log("Unable to get actualSampleRate from device")
+            return nil
+        }
+
+        let totalFrames = latency(scope: scope)
+        return TimeInterval(totalFrames) / sampleRate
+    }
+}
+
+public extension AudioDevice {
     /// The latency in frames for the specified scope.
+    /// Corresponds to the CoreAudio `kAudioDevicePropertyLatency` property
     ///
     /// - Parameter scope: A scope.
     ///
     /// - Returns: *(optional)* A `UInt32` value with the latency in frames.
-    func latency(scope: Scope) -> UInt32? {
+    func deviceLatency(scope: Scope) -> UInt32? {
         guard let address = validAddress(selector: kAudioDevicePropertyLatency,
                                          scope: scope.asPropertyScope) else { return nil }
 
@@ -23,6 +82,8 @@ public extension AudioDevice {
     }
 
     /// The safety offset frames for the specified scope.
+    ///
+    /// Corresponds to the CoreAudio `kAudioDevicePropertySafetyOffset` property
     ///
     /// - Parameter scope: A scope.
     ///
@@ -35,6 +96,8 @@ public extension AudioDevice {
     }
 
     /// The current size of the IO Buffer
+    ///
+    /// Corresponds to the CoreAudio `kAudioDevicePropertyBufferFrameSize` property
     ///
     /// - Parameter scope: A scope.
     ///
@@ -78,7 +141,8 @@ public extension AudioDevice {
               let firstRange = ranges.first else { return nil }
 
         // limit it to these common sizes
-        let possibleBufferSizes: [UInt32] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+        let possibleBufferSizes: [UInt32] = [16, 32, 64, 128, 256,
+                                             512, 1024, 2048, 4096]
 
         guard let lowerBound = possibleBufferSizes.first,
               let upperBound = possibleBufferSizes.last else { return nil }

--- a/Sources/SimplyCoreAudioC/SimplyCoreAudio.c
+++ b/Sources/SimplyCoreAudioC/SimplyCoreAudio.c
@@ -1,1 +1,4 @@
-// SimpleCoreAudioC.c
+/**
+SimpleCoreAudioC.c
+Just here to fulfill the minimum requirements for a framework.
+*/

--- a/Sources/SimplyCoreAudioC/SimplyCoreAudio.h
+++ b/Sources/SimplyCoreAudioC/SimplyCoreAudio.h
@@ -1,3 +1,9 @@
+/**
+ These properties in AudioToolbox.h were renamed in macOS 12. In order to provide backwards compatibility for
+ Xcode versions that are before v13, this creates duplicate properties of the future name. This file does
+ nothing if you're working in Xcode 13+.
+ */
+
 #pragma once
 
 #ifndef SimplyCoreAudio_h

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import SimplyCoreAudio
+import XCTest
 
 final class AudioDeviceTests: SCATestCase {
     func testDeviceLookUp() throws {
@@ -49,14 +49,14 @@ final class AudioDeviceTests: SCATestCase {
         XCTAssertTrue(device.isAlive)
         XCTAssertFalse(device.isRunning)
         XCTAssertFalse(device.isRunningSomewhere)
-        
+
         XCTAssertEqual(device.channels(scope: .output), 2)
         XCTAssertEqual(device.channels(scope: .input), 2)
 
         XCTAssertEqual(device.name(channel: 0, scope: .output), "Master")
         XCTAssertEqual(device.name(channel: 1, scope: .output), "Left")
         XCTAssertEqual(device.name(channel: 2, scope: .output), "Right")
-        
+
         XCTAssertEqual(device.name(channel: 0, scope: .input), "Master")
         XCTAssertEqual(device.name(channel: 1, scope: .input), "Left")
         XCTAssertEqual(device.name(channel: 2, scope: .input), "Right")
@@ -279,17 +279,17 @@ final class AudioDeviceTests: SCATestCase {
 
         XCTAssertTrue(device.setVirtualMainVolume(0.0, scope: .output))
         XCTAssertEqual(device.virtualMainVolume(scope: .output), 0.0)
-        //XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .output), -96.0)
+        // XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .output), -96.0)
         XCTAssertTrue(device.setVirtualMainVolume(0.5, scope: .output))
         XCTAssertEqual(device.virtualMainVolume(scope: .output), 0.5)
-        //XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .output), -70.5)
+        // XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .output), -70.5)
 
         XCTAssertTrue(device.setVirtualMainVolume(0.0, scope: .input))
         XCTAssertEqual(device.virtualMainVolume(scope: .input), 0.0)
-        //XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .input), -96.0)
+        // XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .input), -96.0)
         XCTAssertTrue(device.setVirtualMainVolume(0.5, scope: .input))
         XCTAssertEqual(device.virtualMainVolume(scope: .input), 0.5)
-        //XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .input), -70.5)
+        // XCTAssertEqual(device.virtualMainVolumeInDecibels(scope: .input), -70.5)
     }
 
     func testVirtualMainBalance() throws {
@@ -359,11 +359,11 @@ final class AudioDeviceTests: SCATestCase {
         XCTAssertFalse(device.setClockSourceID(0))
     }
 
-    func testLatency() throws {
+    func testTotalLatency() throws {
         let device = try getNullDevice()
 
-        XCTAssertEqual(device.latency(scope: .output), 0)
-        XCTAssertEqual(device.latency(scope: .input), 0)
+        XCTAssertEqual(device.latency(scope: .output), 512)
+        XCTAssertEqual(device.latency(scope: .input), 512)
     }
 
     func testSafetyOffset() throws {
@@ -371,6 +371,15 @@ final class AudioDeviceTests: SCATestCase {
 
         XCTAssertEqual(device.safetyOffset(scope: .output), 0)
         XCTAssertEqual(device.safetyOffset(scope: .input), 0)
+    }
+    
+    func testBufferFrameSize() throws {
+        let device = try getNullDevice()
+
+        // The IO buffer is generally 512 by default. Also the case
+        // for the NullAudio.driver
+        XCTAssertEqual(device.bufferFrameSize(scope: .output), 512)
+        XCTAssertEqual(device.bufferFrameSize(scope: .input), 512)
     }
 
     func testHogMode() throws {


### PR DESCRIPTION
A bit more logical latency info. Given that the latency for a device requires this 4 part summation, I think it makes sense to have this convenience in here as that's pretty unintuitive.