### PR TITLE
needed static for kAudioObjectPropertyElementMain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     
     products: [
         .library(name: "SimplyCoreAudio",
+                 type: .static,
                  targets: ["SimplyCoreAudio"])
     ],
     

--- a/Sources/SimplyCoreAudioC/SimplyCoreAudio.c
+++ b/Sources/SimplyCoreAudioC/SimplyCoreAudio.c
@@ -1,4 +1,5 @@
 /**
 SimpleCoreAudioC.c
+ 
 Just here to fulfill the minimum requirements for a framework.
 */

--- a/Sources/SimplyCoreAudioC/SimplyCoreAudio.h
+++ b/Sources/SimplyCoreAudioC/SimplyCoreAudio.h
@@ -1,7 +1,7 @@
 /**
- These properties in AudioToolbox.h were renamed in macOS 12. In order to provide backwards compatibility for
- Xcode versions that are before v13, this creates duplicate properties of the future name. This file does
- nothing if you're working in Xcode 13+.
+   These properties in AudioToolbox.h were renamed in macOS 12. In order to provide backwards compatibility for
+   Xcode versions that are before v13, this creates duplicate properties of the future name. This file does
+   nothing if you're working in Xcode 13+.
  */
 
 #pragma once
@@ -12,20 +12,24 @@
 #include <Availability.h>
 #import <AudioToolbox/AudioToolbox.h>
 
-#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
-    #if __MAC_OS_X_VERSION_MAX_ALLOWED < 120000
-
-        CF_ENUM(AudioObjectPropertySelector)
-        {
-            kAudioHardwareServiceDeviceProperty_VirtualMainVolume = kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
-            kAudioHardwareServiceDeviceProperty_VirtualMainBalance = kAudioHardwareServiceDeviceProperty_VirtualMasterBalance
-        };
-
-        AudioObjectPropertyScope kAudioObjectPropertyElementMain = kAudioObjectPropertyElementMaster;
-
-        #define kAudioAggregateDeviceMainSubDeviceKey "master"
-
-    #endif
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
+#define HAVE_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN 1
 #endif
 
+#ifndef HAVE_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN
+
+CF_ENUM(AudioObjectPropertySelector)
+{
+	kAudioHardwareServiceDeviceProperty_VirtualMainVolume = kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
+	kAudioHardwareServiceDeviceProperty_VirtualMainBalance = kAudioHardwareServiceDeviceProperty_VirtualMasterBalance
+};
+
+static AudioObjectPropertyScope kAudioObjectPropertyElementMain = kAudioObjectPropertyElementMaster;
+
+#endif /* HAVE_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN */
+
+#ifndef kAudioAggregateDeviceMainSubDeviceKey
+#define kAudioAggregateDeviceMainSubDeviceKey "master"
 #endif
+
+#endif /* SimplyCoreAudio_h */

--- a/Tests/SimplyCoreAudioTests/SimplyCoreAudioCTests.swift
+++ b/Tests/SimplyCoreAudioTests/SimplyCoreAudioCTests.swift
@@ -3,19 +3,17 @@
 import XCTest
 
 class SimplyCoreAudioCTests: XCTestCase {
-    
-// TODO: causes duplicate symbol error on 12.5.1
-//    func testAPIDeprecations() {
-//        let vmvc = kAudioHardwareServiceDeviceProperty_VirtualMainVolume
-//        let vmbc = kAudioHardwareServiceDeviceProperty_VirtualMainBalance
-//        let elementMain = kAudioObjectPropertyElementMain
-//        let subDeviceKey = kAudioAggregateDeviceMainSubDeviceKey
-//
-//        Swift.print(vmvc, vmbc, elementMain, subDeviceKey)
-//
-//        XCTAssertEqual(vmvc, 1986885219)
-//        XCTAssertEqual(vmbc, 1986880099)
-//        XCTAssertEqual(elementMain, 0)
-//        XCTAssertEqual(subDeviceKey, "master")
-//    }
+    func testAPIChanges() {
+        let vmvc = kAudioHardwareServiceDeviceProperty_VirtualMainVolume
+        let vmbc = kAudioHardwareServiceDeviceProperty_VirtualMainBalance
+        let elementMain = kAudioObjectPropertyElementMain
+        let subDeviceKey = kAudioAggregateDeviceMainSubDeviceKey
+
+        Swift.print(vmvc, vmbc, elementMain, subDeviceKey)
+
+        XCTAssertEqual(vmvc, 1986885219)
+        XCTAssertEqual(vmbc, 1986880099)
+        XCTAssertEqual(elementMain, 0)
+        XCTAssertEqual(subDeviceKey, "master")
+    }
 }


### PR DESCRIPTION
was being included in multiple targets, so duplicate symbol error in the linker.