### PR TITLE
Add convenience method canSetVirtualMainBalance

### DIFF
--- a/Sources/SimplyCoreAudio/Public/AudioDevice+VirtualMainOutput.swift
+++ b/Sources/SimplyCoreAudio/Public/AudioDevice+VirtualMainOutput.swift
@@ -90,6 +90,18 @@ public extension AudioDevice {
         return virtualMainVolumeInDecibels(scope: scope)
     }
 
+    /// Whether the main balance can be set for a given scope.
+    ///
+    /// - Parameter scope: A scope.
+    ///
+    /// - Returns: `true` when the balance can be set, `false` otherwise.
+    func canSetVirtualMainBalance(scope: Scope) -> Bool {
+        guard validAddress(selector: kAudioHardwareServiceDeviceProperty_VirtualMainBalance,
+                           scope: scope.asPropertyScope) != nil else { return false }
+
+        return true
+    }
+
     /// The virtual main balance for a given scope.
     ///
     /// The range is from 0 (all power to the left) to 1 (all power to the right) with the value of 0.5 signifying

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -295,6 +295,9 @@ final class AudioDeviceTests: SCATestCase {
     func testVirtualMainBalance() throws {
         let device = try getNullDevice()
 
+        XCTAssertTrue(device.canSetVirtualMainBalance(scope: .output))
+        XCTAssertTrue(device.canSetVirtualMainBalance(scope: .input))
+
         XCTAssertFalse(device.setVirtualMainBalance(0.0, scope: .output))
         XCTAssertNil(device.virtualMainBalance(scope: .output))
 


### PR DESCRIPTION
## What

Adds a convenience method `canSetVirtualMainBalance` for checking if main balance can be set for audio device output. This would complement the existing `canSetVirtualMainVolume` method.

## Why

As mentioned in https://github.com/rnine/SimplyCoreAudio/issues/59, I've found the system audio device for Macbook Pro M1 cannot get/set the balance. Having this method in this library would be helpful and save a few lines of code in my app 😸  