### PR TITLE
os_log was crashing in setProperty<T>

### DIFF
--- a/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
@@ -292,7 +292,7 @@ extension AudioObject {
 
     func validAddress(selector: AudioObjectPropertySelector,
                       scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
-                      element: AudioObjectPropertyElement = Element.main.asPropertyElement) -> AudioObjectPropertyAddress? {
+                      element: AudioObjectPropertyElement = Element.main.asPropertyElement)-> AudioObjectPropertyAddress? {
         var address = self.address(selector: selector, scope: scope, element: element)
 
         guard AudioObjectHasProperty(objectID, &address) else { return nil }
@@ -350,11 +350,9 @@ extension AudioObject {
         if let unwrappedValue = value as? Bool {
             var newValue: UInt32 = unwrappedValue == true ? 1 : 0
             status = setPropertyData(address, andValue: &newValue)
-
         } else if let unwrappedValue = value as? String {
             var newValue: CFString = unwrappedValue as CFString
             status = setPropertyData(address, andValue: &newValue)
-
         } else {
             var newValue = value
             status = setPropertyData(address, andValue: &newValue)

--- a/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
@@ -364,10 +364,6 @@ extension AudioObject {
         case noErr:
             return true
         default:
-            os_log("Unable to set property. Status: %@",
-                   log: .default,
-                   type: .debug,
-                   status)
             return false
         }
     }

--- a/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
@@ -362,10 +362,10 @@ extension AudioObject {
         case noErr:
             return true
         default:
-            os_log("Unable to set property with address (%@). Status: %@",
-                   log: .default,
-                   type: .debug,
-                   String(describing: address), status)
+//            os_log("Unable to set property with address (%@). Status: %@",
+//                   log: .default,
+//                   type: .debug,
+//                   String(describing: address), status)
             return false
         }
     }

--- a/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
+++ b/Sources/SimplyCoreAudio/Internal/Extensions/AudioObject+Helpers.swift
@@ -292,7 +292,7 @@ extension AudioObject {
 
     func validAddress(selector: AudioObjectPropertySelector,
                       scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
-                      element: AudioObjectPropertyElement = Element.main.asPropertyElement)-> AudioObjectPropertyAddress? {
+                      element: AudioObjectPropertyElement = Element.main.asPropertyElement) -> AudioObjectPropertyAddress? {
         var address = self.address(selector: selector, scope: scope, element: element)
 
         guard AudioObjectHasProperty(objectID, &address) else { return nil }
@@ -350,9 +350,11 @@ extension AudioObject {
         if let unwrappedValue = value as? Bool {
             var newValue: UInt32 = unwrappedValue == true ? 1 : 0
             status = setPropertyData(address, andValue: &newValue)
+
         } else if let unwrappedValue = value as? String {
             var newValue: CFString = unwrappedValue as CFString
             status = setPropertyData(address, andValue: &newValue)
+
         } else {
             var newValue = value
             status = setPropertyData(address, andValue: &newValue)
@@ -362,10 +364,10 @@ extension AudioObject {
         case noErr:
             return true
         default:
-//            os_log("Unable to set property with address (%@). Status: %@",
-//                   log: .default,
-//                   type: .debug,
-//                   String(describing: address), status)
+            os_log("Unable to set property. Status: %@",
+                   log: .default,
+                   type: .debug,
+                   status)
             return false
         }
     }

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -325,8 +325,8 @@ final class AudioDeviceTests: SCATestCase {
         let device = try getNullDevice()
 
         XCTAssertEqual(device.nominalSampleRates, [44_100, 48_000])
-
         XCTAssertFalse(device.setNominalSampleRate(24_000))
+        XCTAssertFalse(device.setNominalSampleRate(96_000))
     }
 
     func testDataSource() throws {

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -308,17 +308,25 @@ final class AudioDeviceTests: SCATestCase {
     func testSampleRate() throws {
         let device = try getNullDevice()
 
-        XCTAssertEqual(device.nominalSampleRates, [44100, 48000])
+        XCTAssertEqual(device.nominalSampleRates, [44_100, 48_000])
 
-        XCTAssertTrue(device.setNominalSampleRate(44100))
+        XCTAssertTrue(device.setNominalSampleRate(44_100))
         sleep(1)
-        XCTAssertEqual(device.nominalSampleRate, 44100)
-        XCTAssertEqual(device.actualSampleRate, 44100)
+        XCTAssertEqual(device.nominalSampleRate, 44_100)
+        XCTAssertEqual(device.actualSampleRate, 44_100)
 
-        XCTAssertTrue(device.setNominalSampleRate(48000))
+        XCTAssertTrue(device.setNominalSampleRate(48_000))
         sleep(1)
-        XCTAssertEqual(device.nominalSampleRate, 48000)
-        XCTAssertEqual(device.actualSampleRate, 48000)
+        XCTAssertEqual(device.nominalSampleRate, 48_000)
+        XCTAssertEqual(device.actualSampleRate, 48_000)
+    }
+
+    func testInvalidSampleRate() throws {
+        let device = try getNullDevice()
+
+        XCTAssertEqual(device.nominalSampleRates, [44_100, 48_000])
+
+        XCTAssertFalse(device.setNominalSampleRate(24_000))
     }
 
     func testDataSource() throws {
@@ -375,7 +383,7 @@ final class AudioDeviceTests: SCATestCase {
         XCTAssertEqual(device.safetyOffset(scope: .output), 0)
         XCTAssertEqual(device.safetyOffset(scope: .input), 0)
     }
-    
+
     func testBufferFrameSize() throws {
         let device = try getNullDevice()
 

--- a/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
+++ b/Tests/SimplyCoreAudioTests/AudioDeviceTests.swift
@@ -295,8 +295,8 @@ final class AudioDeviceTests: SCATestCase {
     func testVirtualMainBalance() throws {
         let device = try getNullDevice()
 
-        XCTAssertTrue(device.canSetVirtualMainBalance(scope: .output))
-        XCTAssertTrue(device.canSetVirtualMainBalance(scope: .input))
+        XCTAssertFalse(device.canSetVirtualMainBalance(scope: .output))
+        XCTAssertFalse(device.canSetVirtualMainBalance(scope: .input))
 
         XCTAssertFalse(device.setVirtualMainBalance(0.0, scope: .output))
         XCTAssertNil(device.virtualMainBalance(scope: .output))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2917795/189969913-1f5f45e3-10a7-44e9-a68e-25d8daaf648d.png)

```swift
func setProperty<T>(address: AudioObjectPropertyAddress, value: T)
```

was crashing due to the os_log statement. I'm not actually sure why, but as it's not really needed I am removing it.