### PR TITLE
fix: set package library type to auto

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
     
     products: [
         .library(name: "SimplyCoreAudio",
-                 type: .static,
                  targets: ["SimplyCoreAudio"])
     ],
     


### PR DESCRIPTION
This addresses SwiftUI previews not working in Xcode 14: #71 
